### PR TITLE
fix updateResponseHeaders

### DIFF
--- a/proxy/handlers/agent.ts
+++ b/proxy/handlers/agent.ts
@@ -1,7 +1,7 @@
 import { HttpRequest, Logger } from '@azure/functions'
 import { config } from '../utils/config'
 import * as https from 'https'
-import { filterRequestHeaders, updateResponseHeaders } from '../utils/headers'
+import { filterRequestHeaders, updateResponseHeadersForAgentDownload } from '../utils/headers'
 import { HttpResponseSimple } from '@azure/functions/types/http'
 import { addTrafficMonitoringSearchParamsForProCDN } from '../utils/traffic'
 import { IntegrationError } from '../errors/IntegrationError'
@@ -57,7 +57,7 @@ export async function downloadAgent({ httpRequest, logger, path }: DownloadAgent
 
         response.on('end', () => {
           const body = Buffer.concat(data)
-          const responseHeaders = updateResponseHeaders(response.headers, domain)
+          const responseHeaders = updateResponseHeadersForAgentDownload(response.headers, domain)
 
           resolve({
             status: response.statusCode ?? 500,

--- a/proxy/handlers/ingress.test.ts
+++ b/proxy/handlers/ingress.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@azure/functions'
 import proxy from '../index'
 import * as ingress from './ingress'
-import https from 'https'
+import https, { Agent } from 'https'
 import { ClientRequest, IncomingMessage } from 'http'
 import { Socket } from 'net'
 
@@ -128,9 +128,11 @@ describe('Result Endpoint', function () {
 
   test('HTTP GET without suffix', async () => {
     const req = mockRequestGet('https://fp.domain.com', 'fpjs/resultId')
-    requestSpy.mockImplementationOnce((url) => {
+    requestSpy.mockImplementationOnce((...args) => {
+      const [url, options] = args
       expect(url.toString()).toBe(`${origin}/${search}`)
-      return Reflect.construct(ClientRequest, url)
+      options.agent = new Agent()
+      return Reflect.construct(ClientRequest, args)
     })
     await proxy(mockContext(req), req)
     expect(ingress.handleIngress).toHaveBeenCalledTimes(1)
@@ -144,13 +146,15 @@ describe('Result Endpoint', function () {
       expect.anything(),
     )
     expect(https.request).toHaveBeenCalledTimes(1)
-  }, 30000)
+  })
 
   test('HTTP GET with suffix', async () => {
     const req = mockRequestGet('https://fp.domain.com', 'fpjs/resultId/with/suffix')
-    requestSpy.mockImplementationOnce((url) => {
+    requestSpy.mockImplementationOnce((...args) => {
+      const [url, options] = args
       expect(url.toString()).toBe(`${origin}/with/suffix${search}`)
-      return Reflect.construct(ClientRequest, url)
+      options.agent = new Agent()
+      return Reflect.construct(ClientRequest, args)
     })
     await proxy(mockContext(req), req)
     expect(ingress.handleIngress).toHaveBeenCalledTimes(1)
@@ -164,20 +168,22 @@ describe('Result Endpoint', function () {
       expect.anything(),
     )
     expect(https.request).toHaveBeenCalledTimes(1)
-  }, 30000)
+  })
 
   test('HTTP GET with bad suffix', async () => {
     const req = mockRequestGet('https://fp.domain.com', 'fpjs/resultIdwith/bad/suffix')
     await proxy(mockContext(req), req)
     expect(ingress.handleIngress).toHaveBeenCalledTimes(0)
     expect(https.request).toHaveBeenCalledTimes(0)
-  }, 30000)
+  })
 
   test('HTTP POST without suffix', async () => {
     const req = mockRequestPost('https://fp.domain.com', 'fpjs/resultId')
-    requestSpy.mockImplementationOnce((url) => {
+    requestSpy.mockImplementationOnce((...args) => {
+      const [url, options] = args
       expect(url.toString()).toBe(`${origin}/${search}`)
-      return Reflect.construct(ClientRequest, url)
+      options.agent = new Agent()
+      return Reflect.construct(ClientRequest, args)
     })
     await proxy(mockContext(req), req)
     expect(ingress.handleIngress).toHaveBeenCalledTimes(1)
@@ -191,13 +197,15 @@ describe('Result Endpoint', function () {
       expect.anything(),
     )
     expect(https.request).toHaveBeenCalledTimes(1)
-  }, 30000)
+  })
 
   test('HTTP POST with suffix', async () => {
     const req = mockRequestPost('https://fp.domain.com', 'fpjs/resultId/with/suffix')
-    requestSpy.mockImplementationOnce((url) => {
+    requestSpy.mockImplementationOnce((...args) => {
+      const [url, options] = args
       expect(url.toString()).toBe(`${origin}/with/suffix${search}`)
-      return Reflect.construct(ClientRequest, url)
+      options.agent = new Agent()
+      return Reflect.construct(ClientRequest, args)
     })
     await proxy(mockContext(req), req)
     expect(ingress.handleIngress).toHaveBeenCalledTimes(1)
@@ -211,14 +219,14 @@ describe('Result Endpoint', function () {
       expect.anything(),
     )
     expect(https.request).toHaveBeenCalledTimes(1)
-  }, 30000)
+  })
 
   test('HTTP POST with bad suffix', async () => {
     const req = mockRequestPost('https://fp.domain.com', 'fpjs/resultIdwith/bad/suffix')
     await proxy(mockContext(req), req)
     expect(ingress.handleIngress).toHaveBeenCalledTimes(0)
     expect(https.request).toHaveBeenCalledTimes(0)
-  }, 30000)
+  })
 })
 
 describe('Browser caching endpoint', () => {
@@ -236,9 +244,11 @@ describe('Browser caching endpoint', () => {
     const cacheControlValue = 'max-age=31536000, immutable, private'
     const responseStream = new IncomingMessage(new Socket())
     responseStream.headers['cache-control'] = cacheControlValue
-    requestSpy.mockImplementationOnce((_url, _options, cb) => {
+    requestSpy.mockImplementationOnce((...args) => {
+      const [, options, cb] = args
       cb(responseStream)
-      return Reflect.construct(ClientRequest, [_url, _options, cb])
+      options.agent = new Agent()
+      return Reflect.construct(ClientRequest, args)
     })
     const req = mockRequestPost('https://fp.domain.com', 'fpjs/resultId/with/suffix')
     const response = await proxy(mockContext(req), req)

--- a/proxy/utils/headers.ts
+++ b/proxy/utils/headers.ts
@@ -34,7 +34,14 @@ export function filterRequestHeaders(headers: HttpRequestHeaders) {
   }, {})
 }
 
-export function updateResponseHeaders(headers: http.IncomingHttpHeaders, domain: string): HttpResponseHeaders {
+export const updateResponseHeadersForAgentDownload = (headers: http.IncomingHttpHeaders, domain: string) =>
+  updateResponseHeaders(headers, domain, true)
+
+export function updateResponseHeaders(
+  headers: http.IncomingHttpHeaders,
+  domain: string,
+  overrideCacheControl = false,
+): HttpResponseHeaders {
   const result: HttpResponseHeaders = {}
 
   for (const [key, value] of Object.entries(headers)) {
@@ -50,7 +57,11 @@ export function updateResponseHeaders(headers: http.IncomingHttpHeaders, domain:
       }
 
       case CACHE_CONTROL_HEADER_NAME: {
-        result[CACHE_CONTROL_HEADER_NAME] = updateCacheControlHeader(value.toString())
+        if (overrideCacheControl) {
+          result[CACHE_CONTROL_HEADER_NAME] = updateCacheControlHeader(value.toString())
+        } else {
+          result[key] = value.toString()
+        }
 
         break
       }


### PR DESCRIPTION
fix(updateResponseHeaders): only agent download should override cache control header.

Update: This PR uses test mock implementation from [this PR](https://github.com/fingerprintjs/fingerprint-pro-azure-integration/pull/144).