### PR TITLE
[INTER-684] Improve E2E tests resource cleanp

### DIFF
--- a/e2e/infra/infra.ts
+++ b/e2e/infra/infra.ts
@@ -61,7 +61,6 @@ export async function deployE2EInfrastructure({
     return {
       waitForFrontDoor,
       testInfo: {
-        resourceGroup,
         frontdoorUrl,
         functionAppUrl: `https://${functionAppHost}`,
         websiteUrl: website.url,

--- a/e2e/infra/scripts/deploy.ts
+++ b/e2e/infra/scripts/deploy.ts
@@ -1,5 +1,5 @@
 import { createResourceGroup, removeResourceGroup } from '../resourceGroup'
-import { writeTestInfo } from '../../shared/testInfo'
+import { addTestInfo, initTestInfo } from '../../shared/testInfo'
 import { deployE2EInfrastructure, DeployE2EInfrastructureOptions, DeployE2EInfrastructureResult } from '../infra'
 import { destroyTestInfo } from '../destroyTestInfo'
 
@@ -9,6 +9,8 @@ function getId() {
 
 async function main() {
   const resourceGroup = await createResourceGroup()
+
+  initTestInfo(resourceGroup)
 
   const results: DeployE2EInfrastructureResult[] = []
 
@@ -32,11 +34,11 @@ async function main() {
       const result = await deployE2EInfrastructure(variant)
 
       results.push(result)
+
+      addTestInfo(result.testInfo)
     }
 
     await Promise.all(results.map((r) => r.waitForFrontDoor()))
-
-    writeTestInfo(results.map((r) => r.testInfo))
   } catch (error) {
     for (const result of results) {
       await destroyTestInfo(result.testInfo)

--- a/e2e/infra/scripts/destroy.ts
+++ b/e2e/infra/scripts/destroy.ts
@@ -5,15 +5,11 @@ import { destroyTestInfo } from '../destroyTestInfo'
 async function main() {
   const testInfo = readTestInfo()
 
-  const resourceGroups = new Set(testInfo.map((t) => t.resourceGroup))
-
-  for (const info of testInfo) {
+  for (const info of testInfo.tests) {
     await destroyTestInfo(info)
   }
 
-  for (const resourceGroup of resourceGroups) {
-    await removeResourceGroup(resourceGroup)
-  }
+  await removeResourceGroup(testInfo.resourceGroup)
 
   deleteTestInfo()
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -20,7 +20,7 @@ const config: Config = {
   expect: {
     timeout: isCi ? 100_000 : 30_000,
   },
-  projects: testInfo.map((info) => ({
+  projects: testInfo.tests.map((info) => ({
     use: {
       name: info.frontdoorUrl,
       baseURL: info.frontdoorUrl,

--- a/e2e/scripts/mockTests.ts
+++ b/e2e/scripts/mockTests.ts
@@ -12,7 +12,7 @@ async function main() {
     throw new Error('API_URL is not set')
   }
 
-  for (const info of testInfo) {
+  for (const info of testInfo.tests) {
     const agentPath = `${info.routePrefix}/${info.agentDownloadPath}`
     const resultPath = `${info.routePrefix}/${info.getResultPath}`
     const host = info.functionAppUrl

--- a/e2e/shared/testInfo.ts
+++ b/e2e/shared/testInfo.ts
@@ -2,7 +2,6 @@ import * as fs from 'fs'
 import path from 'path'
 
 export interface TestInfo {
-  resourceGroup: string
   functionAppUrl: string
   websiteUrl: string
   frontdoorUrl: string
@@ -13,13 +12,37 @@ export interface TestInfo {
   routePrefix: string
 }
 
+export interface TestMetadata {
+  resourceGroup: string
+  tests: TestInfo[]
+}
+
 const filePath = path.join(__dirname, '..', 'test-info.json')
 
-export function writeTestInfo(info: TestInfo[]) {
+export function initTestInfo(resourceGroup: string) {
+  if (fs.existsSync(filePath)) {
+    throw new Error('Test info file already exists')
+  }
+
+  writeTestInfo({
+    tests: [],
+    resourceGroup,
+  })
+}
+
+export function addTestInfo(testInfo: TestInfo) {
+  const infos = readTestInfo()
+
+  infos.tests.push(testInfo)
+
+  writeTestInfo(infos)
+}
+
+export function writeTestInfo(info: TestMetadata) {
   fs.writeFileSync(filePath, JSON.stringify(info))
 }
 
-export function readTestInfo(): TestInfo[] {
+export function readTestInfo(): TestMetadata {
   if (!fs.existsSync(filePath)) {
     throw new Error('Test info file does not exist')
   }

--- a/e2e/tests/pwTest.ts
+++ b/e2e/tests/pwTest.ts
@@ -6,7 +6,7 @@ import invariant from 'tiny-invariant'
 export const test = baseTest.extend<{ azureTestInfo: TestInfo }>({
   azureTestInfo: async ({ baseURL }, use) => {
     const testInfo = readTestInfo()
-    const project = testInfo.find((info) => info.frontdoorUrl === baseURL)
+    const project = testInfo.tests.find((info) => info.frontdoorUrl === baseURL)
 
     invariant(project, 'project is required')
 

--- a/e2e/tests/setup.ts
+++ b/e2e/tests/setup.ts
@@ -9,7 +9,7 @@ export default async function setup(config: FullConfig) {
   const targets = config.projects.map((p) => ({
     name: p.name,
     url: p.use.baseURL,
-    testInfo: testInfo.find((info) => info.frontdoorUrl === p.use.baseURL),
+    testInfo: testInfo.tests.find((info) => info.frontdoorUrl === p.use.baseURL),
     headless: p.use.headless,
   }))
 


### PR DESCRIPTION
- Rework test info storage
- Store resource group name early, so that the cleanup can work even if deployment didn't fully finish