### PR TITLE
fix: send other proxy headers even if proxy secret is undefined INTER-1157

### DIFF
--- a/proxy/utils/headers.test.ts
+++ b/proxy/utils/headers.test.ts
@@ -160,27 +160,21 @@ describe('updateResponseHeadersForAgentDownload', () => {
 })
 
 describe('prepareHeadersForIngressAPI', () => {
-  it('should set client ip and proxy secret', () => {
+  it('should set all proxy headers if proxy secret is defined, preserving the original headers', () => {
     const result = prepareHeadersForIngressAPI(mockReq, 'secret')
 
     expect(result['fpjs-proxy-client-ip']).toBe('127.0.0.1')
     expect(result['fpjs-proxy-secret']).toBe('secret')
     expect(result['fpjs-proxy-forwarded-host']).toBe('fpjs.sh')
+    expect(result['x-custom-header']).toBe(mockReq.headers['x-custom-header'])
   })
 
-  it('should set correct host', () => {
-    const result = prepareHeadersForIngressAPI(mockReq, 'secret')
-
-    expect(result['fpjs-proxy-client-ip']).toBe('127.0.0.1')
-    expect(result['fpjs-proxy-secret']).toBe('secret')
-    expect(result['fpjs-proxy-forwarded-host']).toBe('fpjs.sh')
-  })
-
-  it('should not set secret if it is undefined', () => {
+  it('should set the other proxy headers, even if proxy secret is not defined, preserving the original headers', () => {
     const result = prepareHeadersForIngressAPI(mockReq, undefined)
 
     expect(result['fpjs-proxy-client-ip']).toBe('127.0.0.1')
+    expect(result['fpjs-proxy-forwarded-host']).toBe('fpjs.sh')
     expect(result['fpjs-proxy-secret']).toBe(undefined)
-    expect(result['fpjs-proxy-forwarded-host']).toBe(undefined)
+    expect(result['x-custom-header']).toBe(mockReq.headers['x-custom-header'])
   })
 })

--- a/proxy/utils/headers.ts
+++ b/proxy/utils/headers.ts
@@ -88,10 +88,10 @@ export function prepareHeadersForIngressAPI(request: HttpRequest, preSharedSecre
   const headers = filterRequestHeaders(request.headers)
 
   headers['fpjs-proxy-client-ip'] = resolveClientIp(request, logger)
+  headers['fpjs-proxy-forwarded-host'] = getHost(request)
 
   if (preSharedSecret) {
     headers['fpjs-proxy-secret'] = preSharedSecret
-    headers['fpjs-proxy-forwarded-host'] = getHost(request)
   }
 
   return headers


### PR DESCRIPTION
* Always send client IP and forwarded host proxy headers, even if the proxy secret is undefined.
* Adjusted tests.