### PR TITLE
chore: set Datadog team in e2e-tests workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,6 +13,12 @@ permissions:
   contents: read
 
 jobs:
+  set_datadog_team:
+    name: Set Datadog team
+    uses: fingerprintjs/dx-team-toolkit/.github/workflows/set-datadog-team.yml@v1
+    secrets:
+      DD_API_KEY: ${{ secrets.INTEGRATIONS_DATADOG_API_KEY }}
+
   mock-e2e:
     name: Mock E2E
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add a job to the `e2e-tests` workflow to set the Datadog team for the workflow execution in Datadog. This is required to have the scheduled execution show up on the daily reports and dashboard.