### PR TITLE
[INTER-2197] E2E tests improvements

### DIFF
--- a/.github/workflows/cleanup-dangling-resource-groups.yml
+++ b/.github/workflows/cleanup-dangling-resource-groups.yml
@@ -1,0 +1,51 @@
+name: Cleanup dangling resource groups
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Only log resource groups that would be deleted'
+        type: boolean
+        default: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  cleanup:
+    name: Cleanup
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Azure OIDC token is configured to run on this env
+    environment: dev
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure Login
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: 'Install latest node version'
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+
+      - name: 'Install pnpm'
+        uses: pnpm/action-setup@129abb77bf5884e578fcaf1f37628e41622cc371
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Cleanup dangling resource groups
+        run: pnpm cleanup-dangling-resource-groups
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          DRY_RUN: ${{ inputs.dry_run }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -84,6 +84,7 @@ jobs:
 
       - name: Azure Re-Login
         uses: azure/login@v3
+        if: always()
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -82,6 +82,13 @@ jobs:
           CI: 'true'
           API_URL: ${{ secrets.MOCK_INGRESS_API }}
 
+      - name: Azure Re-Login
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: Destroy infrastructure
         if: always()
         run: pnpm e2e-destroy-infra

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -162,6 +162,14 @@ jobs:
         env:
           CI: 'true'
 
+      - name: Azure Re-Login
+        uses: azure/login@v3
+        if: always()
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: Destroy infrastructure
         if: always()
         run: pnpm e2e-destroy-infra

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "start": "cd dist && func start",
     "start:example-website": "cd example-website && vite",
     "build:example-website": "cd example-website && vite build",
+    "cleanup-dangling-resource-groups": "ts-node --project scripts/tsconfig.json scripts/cleanupDanglingResourceGroups.ts",
     "e2e-deploy-infra": "ts-node --project e2e/tsconfig.json e2e/infra/scripts/deploy.ts",
     "e2e-destroy-infra": "ts-node --project e2e/tsconfig.json e2e/infra/scripts/destroy.ts",
     "changeset:publish": "HUSKY=0 changeset publish && pnpm build:release && pnpm prepare-package",

--- a/scripts/cleanupDanglingResourceGroups.ts
+++ b/scripts/cleanupDanglingResourceGroups.ts
@@ -1,0 +1,72 @@
+import { DefaultAzureCredential } from '@azure/identity'
+import { ResourceManagementClient } from '@azure/arm-resources'
+
+const RESOURCE_GROUP_NAME_REGEX = /^fpjs-dev-e2e-(\d+)$/
+const MAX_AGE_MS = 6 * 60 * 60 * 1000
+
+async function main() {
+  const subscriptionId = process.env.AZURE_SUBSCRIPTION_ID
+  if (!subscriptionId) {
+    throw new Error('AZURE_SUBSCRIPTION_ID is required')
+  }
+
+  const dryRun = process.env.DRY_RUN === 'true'
+  const now = Date.now()
+
+  const client = new ResourceManagementClient(new DefaultAzureCredential(), subscriptionId)
+
+  const deletions: Promise<unknown>[] = []
+  let scanned = 0
+  let matched = 0
+  let stale = 0
+
+  for await (const group of client.resourceGroups.list()) {
+    scanned++
+    const name = group.name
+    if (!name) {
+      continue
+    }
+
+    const match = name.match(RESOURCE_GROUP_NAME_REGEX)
+    if (!match) {
+      continue
+    }
+    matched++
+
+    const timestamp = Number(match[1])
+    if (!Number.isFinite(timestamp)) {
+      console.warn(`Skipping ${name}: invalid timestamp`)
+      continue
+    }
+
+    const ageMs = now - timestamp
+    if (ageMs <= MAX_AGE_MS) {
+      console.info(`Keeping ${name} (age ${Math.round(ageMs / 60000)}m)`)
+      continue
+    }
+
+    stale++
+    const ageHours = (ageMs / (60 * 60 * 1000)).toFixed(1)
+    if (dryRun) {
+      console.info(`[dry-run] Would delete ${name} (age ${ageHours}h)`)
+      continue
+    }
+
+    console.info(`Deleting ${name} (age ${ageHours}h)`)
+    deletions.push(
+      client.resourceGroups
+        .beginDelete(name)
+        .then(() => console.info(`Initiated deletion of ${name}`))
+        .catch((err) => console.error(`Failed to delete ${name}:`, err))
+    )
+  }
+
+  await Promise.all(deletions)
+
+  console.info(`Done. Scanned ${scanned} groups, matched ${matched}, stale ${stale}.`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/cleanupDanglingResourceGroups.ts
+++ b/scripts/cleanupDanglingResourceGroups.ts
@@ -2,6 +2,7 @@ import { DefaultAzureCredential } from '@azure/identity'
 import { ResourceManagementClient } from '@azure/arm-resources'
 
 const RESOURCE_GROUP_NAME_REGEX = /^fpjs-dev-e2e-(\d+)$/
+// 6h
 const MAX_AGE_MS = 6 * 60 * 60 * 1000
 
 async function main() {


### PR DESCRIPTION
This pull request introduces automated cleanup for Azure resource groups used in end-to-end (E2E) testing, along with improvements to the E2E test workflow to ensure proper Azure authentication before destroying infrastructure. The main goal is to prevent accumulation of stale resource groups and reduce manual maintenance.

**Automated resource group cleanup:**

* Added a new workflow `.github/workflows/cleanup-dangling-resource-groups.yml` that runs nightly and can be triggered manually to delete old Azure resource groups matching the `fpjs-dev-e2e-<timestamp>` pattern, with a dry-run option for safety.
* Introduced a new script `scripts/cleanupDanglingResourceGroups.ts` that identifies and deletes resource groups older than 6 hours, with clear logging and a dry-run mode.
* Registered the cleanup script as an npm script `cleanup-dangling-resource-groups` in `package.json` for easy execution.

**E2E workflow reliability:**

* Updated `.github/workflows/e2e-tests.yml` to add an explicit Azure re-login step before destroying infrastructure, ensuring authentication is valid even if earlier steps fail. [[1]](diffhunk://#diff-194218c48b9a0cdd03974145733804c2d992ca818529fe2fa69a501d8b5b1cc3R85-R92) [[2]](diffhunk://#diff-194218c48b9a0cdd03974145733804c2d992ca818529fe2fa69a501d8b5b1cc3R165-R172)